### PR TITLE
Update 05-counting-mining.md

### DIFF
--- a/_episodes/05-counting-mining.md
+++ b/_episodes/05-counting-mining.md
@@ -570,7 +570,7 @@ $ wc -l results/*.tsv
 > `"+%Y-%m-%d"` option and alternative options we could have used.
 >
 > > ## Solution
-> > Using `date --help` will show you that the `+` option introduces
+> > Using `man date` (on Linux and MacOS X) or `date --help` (on Git Bash for Windows or Linux) will show you that the `+` option introduces
 > > a date format, where `%Y`, `%m` and `%d` are replaced by the year,
 > > month, and day respectively. There are many other percent-codes
 > > you could use.


### PR DESCRIPTION
Fixes "Automatically adding a date prefix" as requested in issue #131 https://github.com/LibraryCarpentry/lc-shell/issues/131 "date --help" does not work on MacOS and "man date" does not work in Git Bash for Windows, the shell suggested in https://librarycarpentry.org/lc-shell/setup.html
